### PR TITLE
Add /system/lib64 to search path to be able to load 64-bit code.

### DIFF
--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
@@ -117,7 +117,7 @@ public final class CaliperProxyActivity extends Activity {
     String classpath = getApplicationInfo().sourceDir;
     // getApplicationInfo().nativeLibraryDir points to location of native libraries
     // Additionally make system provided native libraries available from /system/lib
-    String nativeLibraryDir = getApplicationInfo().nativeLibraryDir + ":/system/lib";
+    String nativeLibraryDir = getApplicationInfo().nativeLibraryDir + ":/system/lib:/system/lib64";
 
     String androidDataDir = System.getProperty("java.io.tmpdir") + "/data";
     createWritableDalvikCache(androidDataDir);


### PR DESCRIPTION
RELNOTES=Fix issue with incorrectly loading 32-bit code from /system/lib
PiperOrigin-RevId: 379295637